### PR TITLE
Missing "$config" argument

### DIFF
--- a/src/Mews/Purifier/Purifier.php
+++ b/src/Mews/Purifier/Purifier.php
@@ -123,7 +123,7 @@ class Purifier {
             foreach ($dirty as $key => $value)
             {
                 // Recursively clean arrays
-                $clean[$key] = Purifier::clean($value);
+                $clean[$key] = Purifier::clean($value, $config);
             }
         }
         else


### PR DESCRIPTION
The recursively clean arrays doesn't work with dynamic configurations
