### PR TITLE
Add support for cache path and auto-generation if directory is missing

### DIFF
--- a/src/Mews/Purifier/Purifier.php
+++ b/src/Mews/Purifier/Purifier.php
@@ -74,6 +74,7 @@ class Purifier {
 
             // Use the same character set as Laravel
             $config->set('Core.Encoding', Config::get('purifier::config.encoding'));
+            $config->set('Cache.SerializerPath', Config::get('purifier::config.cachePath'));
 
             if (is_array(Config::get('purifier::config.settings.default')))
             {

--- a/src/Mews/Purifier/PurifierServiceProvider.php
+++ b/src/Mews/Purifier/PurifierServiceProvider.php
@@ -1,6 +1,8 @@
 <?php namespace Mews\Purifier;
 
-use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\ServiceProvider,
+    Illuminate\Support\Facades\File,
+    Illuminate\Support\Facades\Config;
 
 class PurifierServiceProvider extends ServiceProvider {
 
@@ -26,6 +28,8 @@ class PurifierServiceProvider extends ServiceProvider {
 	    {
 
 	    });
+
+        $this->makeStorageSerializerDir();
 	}
 
 	/**
@@ -50,5 +54,21 @@ class PurifierServiceProvider extends ServiceProvider {
 	{
 		return array('purifier');
 	}
+
+    /**
+     * Check for cache path, and create if missing
+     */
+    protected function makeStorageSerializerDir()
+    {
+        $purifierCachePath = Config::get('purifier::config.cachePath');
+        if (File::exists($purifierCachePath) === false)
+        {
+            File::makeDirectory($purifierCachePath);
+
+            $gitIgnoreContent = '*';
+            $gitIgnoreContent .= "\n" . '!.gitignore';
+            File::put($purifierCachePath . '/.gitignore', $gitIgnoreContent);
+        }
+    }
 
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,7 @@ return array(
 	'encoding' => 'UTF-8',
     'finalize' => true,
     'preload'  => false,
+    'cachePath' => storage_path('purifier'),
     'settings' => array(
         'default' => array(
             'HTML.Doctype'             => 'XHTML 1.0 Strict',


### PR DESCRIPTION
I figured the problem while using it, because I had to manually create storage dir.
This way that problem would be solved, and it would be possible to configure path to storage, in case you have distributed system, with shared cache, or something.