### PR TITLE
Fixed mockery version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",
-		"mockery/mockery": "dev-master"
+		"mockery/mockery": "^0.9"
 	},
 	"suggest": {
 		"laravel/framework": "To test the Laravel bindings",


### PR DESCRIPTION
Requiring

    "mockery/mockery": "dev-master",

now generates a conflict with 

    "minimum-stability": "stable"

so this fixes the error.
