### PR TITLE
Allow users to configure cache file/directory permissions

### DIFF
--- a/config/purifier.php
+++ b/config/purifier.php
@@ -21,6 +21,7 @@ return [
     'encoding'  => 'UTF-8',
     'finalize'  => true,
     'cachePath' => storage_path('app/purifier'),
+    'cacheFileMode' => 0755,
     'settings'  => [
         'default' => [
             'HTML.Doctype'             => 'XHTML 1.0 Strict',

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -90,7 +90,7 @@ class Purifier
 
         if ($cachePath) {
             if (!$this->files->isDirectory($cachePath)) {
-                $this->files->makeDirectory($cachePath);
+                $this->files->makeDirectory($cachePath, $this->config->get('purifier.cacheFileMode', 0755) );
             }
         }
     }
@@ -113,6 +113,7 @@ class Purifier
         $default_config = [];
         $default_config['Core.Encoding']        = $this->config->get('purifier.encoding');
         $default_config['Cache.SerializerPath'] = $this->config->get('purifier.cachePath');
+        $default_config['Cache.SerializerPermissions'] = $this->config->get('purifier.cacheFileMode', 0755 );
 
         if (!$config) {
             $config = $this->config->get('purifier.settings.default');


### PR DESCRIPTION
Currently all cache files are written with 755 (only the user has write access). We use several users to mange our environment (jenkins, apache, etc...) and in order to make files writable must assign write access at the group level. This patch allows for that. 

I verified:
 * Package behavior is unchanged when no cacheFileMode value is specified
 * The change passes all unit tests