### PR TITLE
Require $config to implement the ConfigContract

### DIFF
--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -17,7 +17,7 @@ namespace Mews\Purifier;
 use Exception;
 use HTMLPurifier;
 use HTMLPurifier_Config;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Filesystem\Filesystem;
 
 class Purifier


### PR DESCRIPTION
This fixes issues with setups that don't use the Laravel provided `Illuminate\Config\Repository` class for their config repository but are still compatible with the rest of the Laravel ecosystem by implementing the `Illuminate\Contracts\Config\Repository` in their Config Repository class.

Specifically in my case, this adds support for using this package within [OctoberCMS](https://github.com/octobercms/october) (most popular Laravel-based CMS) - as October uses `October\Rain\Config\Repository` which is not an instanceof `Illuminate\Config\Repository` but still implements the required `Illuminate\Contracts\Config\Repository` contract that the default Laravel config repository class does as well.