### PR TITLE
Add support for HTML5 and custom definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ return [
             'AutoFormat.RemoveEmpty'   => true,
         ],
         'test'    => [
-            'Attr.EnableID' => true
+            'Attr.EnableID' => 'true',
         ],
         "youtube" => [
             "HTML.SafeIframe"      => 'true',
@@ -110,11 +110,11 @@ return [
 					'poster' => 'URI',
 					'preload' => 'Enum#auto,metadata,none',
 					'controls' => 'Bool',
-                ],
+                ]],
                 ['source', 'Block', 'Flow', 'Common', [
 					'src' => 'URI',
 					'type' => 'Text',
-                ],
+                ]],
 
 				// http://developers.whatwg.org/text-level-semantics.html
                 ['s',    'Inline', 'Inline', 'Common'],
@@ -125,8 +125,8 @@ return [
                 ['wbr',  'Inline', 'Empty', 'Core'],
 				
 				// http://developers.whatwg.org/edits.html
-                ['ins', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
-                ['del', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
+                ['ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+                ['del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
             ],
             'attributes' => [
                 ['iframe', 'allowfullscreen', 'Bool'],

--- a/README.md
+++ b/README.md
@@ -61,25 +61,88 @@ Config file `config/purifier.php` should like this
 ```php
 
 return [
-
-    'encoding' => 'UTF-8',
-    'finalize' => true,
-    'preload'  => false,
-    'cachePath' => null,
-    'settings' => [
+    'encoding'      => 'UTF-8',
+    'finalize'      => true,
+    'cachePath'     => storage_path('app/purifier'),
+    'cacheFileMode' => 0755,
+    'settings'      => [
         'default' => [
-            'HTML.Doctype'             => 'XHTML 1.0 Strict',
-            'HTML.Allowed'             => 'div,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'HTML.Doctype'             => 'HTML 4.01 Transitional',
+            'HTML.Allowed'             => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
             'CSS.AllowedProperties'    => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
             'AutoFormat.AutoParagraph' => true,
-            'AutoFormat.RemoveEmpty'   => true
+            'AutoFormat.RemoveEmpty'   => true,
         ],
-        'test' => [
+        'test'    => [
             'Attr.EnableID' => true
         ],
         "youtube" => [
-            "HTML.SafeIframe" => 'true',
+            "HTML.SafeIframe"      => 'true',
             "URI.SafeIframeRegexp" => "%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%",
+        ],
+        'custom_definition' => [
+            'id'  => 'html5-definitions',
+            'rev' => 1,
+            'debug' => false,
+            'elements' => [
+                // http://developers.whatwg.org/sections.html
+                ['section', 'Block', 'Flow', 'Common'],
+                ['nav',     'Block', 'Flow', 'Common'],
+                ['article', 'Block', 'Flow', 'Common'],
+                ['aside',   'Block', 'Flow', 'Common'],
+                ['header',  'Block', 'Flow', 'Common'],
+                ['footer',  'Block', 'Flow', 'Common'],
+				
+				// Content model actually excludes several tags, not modelled here
+                ['address', 'Block', 'Flow', 'Common'],
+                ['hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common'],
+				
+				// http://developers.whatwg.org/grouping-content.html
+                ['figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common'],
+                ['figcaption', 'Inline', 'Flow', 'Common'],
+				
+				// http://developers.whatwg.org/the-video-element.html#the-video-element
+                ['video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+                    'src' => 'URI',
+					'type' => 'Text',
+					'width' => 'Length',
+					'height' => 'Length',
+					'poster' => 'URI',
+					'preload' => 'Enum#auto,metadata,none',
+					'controls' => 'Bool',
+                ],
+                ['source', 'Block', 'Flow', 'Common', [
+					'src' => 'URI',
+					'type' => 'Text',
+                ],
+
+				// http://developers.whatwg.org/text-level-semantics.html
+                ['s',    'Inline', 'Inline', 'Common'],
+                ['var',  'Inline', 'Inline', 'Common'],
+                ['sub',  'Inline', 'Inline', 'Common'],
+                ['sup',  'Inline', 'Inline', 'Common'],
+                ['mark', 'Inline', 'Inline', 'Common'],
+                ['wbr',  'Inline', 'Empty', 'Core'],
+				
+				// http://developers.whatwg.org/edits.html
+                ['ins', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
+                ['del', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
+            ],
+            'attributes' => [
+                ['iframe', 'allowfullscreen', 'Bool'],
+                ['table', 'height', 'Text'],
+                ['td', 'border', 'Text'],
+                ['th', 'border', 'Text'],
+                ['tr', 'width', 'Text'],
+                ['tr', 'height', 'Text'],
+                ['tr', 'border', 'Text'],
+            ],
+        ],
+        'custom_attributes' => [
+            ['a', 'target', 'Enum#_blank,_self,_target,_top'],
+        ],
+        'custom_elements' => [
+            ['u', 'Inline', 'Inline', 'Common'],
         ],
     ],
 

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -30,7 +30,7 @@ return [
             'AutoFormat.RemoveEmpty'   => true,
         ],
         'test'    => [
-            'Attr.EnableID' => true
+            'Attr.EnableID' => 'true',
         ],
         "youtube" => [
             "HTML.SafeIframe"      => 'true',
@@ -66,11 +66,11 @@ return [
 					'poster' => 'URI',
 					'preload' => 'Enum#auto,metadata,none',
 					'controls' => 'Bool',
-                ],
+                ]],
                 ['source', 'Block', 'Flow', 'Common', [
 					'src' => 'URI',
 					'type' => 'Text',
-                ],
+                ]],
 
 				// http://developers.whatwg.org/text-level-semantics.html
                 ['s',    'Inline', 'Inline', 'Common'],
@@ -81,8 +81,8 @@ return [
                 ['wbr',  'Inline', 'Empty', 'Core'],
 				
 				// http://developers.whatwg.org/edits.html
-                ['ins', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
-                ['del', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
+                ['ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+                ['del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
             ],
             'attributes' => [
                 ['iframe', 'allowfullscreen', 'Bool'],

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -23,8 +23,8 @@ return [
     'cacheFileMode' => 0755,
     'settings'      => [
         'default' => [
-            'HTML.Doctype'             => 'XHTML 1.0 Strict',
-            'HTML.Allowed'             => 'div,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'HTML.Doctype'             => 'HTML 4.01 Transitional',
+            'HTML.Allowed'             => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
             'CSS.AllowedProperties'    => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
             'AutoFormat.AutoParagraph' => true,
             'AutoFormat.RemoveEmpty'   => true,
@@ -35,6 +35,69 @@ return [
         "youtube" => [
             "HTML.SafeIframe"      => 'true',
             "URI.SafeIframeRegexp" => "%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%",
+        ],
+        'custom_definition' => [
+            'id'  => 'html5-definitions',
+            'rev' => 1,
+            'elements' => [
+                // http://developers.whatwg.org/sections.html
+                ['section', 'Block', 'Flow', 'Common'],
+                ['nav',     'Block', 'Flow', 'Common'],
+                ['article', 'Block', 'Flow', 'Common'],
+                ['aside',   'Block', 'Flow', 'Common'],
+                ['header',  'Block', 'Flow', 'Common'],
+                ['footer',  'Block', 'Flow', 'Common'],
+				
+				// Content model actually excludes several tags, not modelled here
+                ['address', 'Block', 'Flow', 'Common'],
+                ['hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common'],
+				
+				// http://developers.whatwg.org/grouping-content.html
+                ['figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common'],
+                ['figcaption', 'Inline', 'Flow', 'Common'],
+				
+				// http://developers.whatwg.org/the-video-element.html#the-video-element
+                ['video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+                    'src' => 'URI',
+					'type' => 'Text',
+					'width' => 'Length',
+					'height' => 'Length',
+					'poster' => 'URI',
+					'preload' => 'Enum#auto,metadata,none',
+					'controls' => 'Bool',
+                ],
+                ['source', 'Block', 'Flow', 'Common', [
+					'src' => 'URI',
+					'type' => 'Text',
+                ],
+
+				// http://developers.whatwg.org/text-level-semantics.html
+                ['s',    'Inline', 'Inline', 'Common'],
+                ['var',  'Inline', 'Inline', 'Common'],
+                ['sub',  'Inline', 'Inline', 'Common'],
+                ['sup',  'Inline', 'Inline', 'Common'],
+                ['mark', 'Inline', 'Inline', 'Common'],
+                ['wbr',  'Inline', 'Empty', 'Core'],
+				
+				// http://developers.whatwg.org/edits.html
+                ['ins', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
+                ['del', 'Block', 'Flow', 'Common', array('cite' => 'URI', 'datetime' => 'CDATA')],
+            ],
+            'attributes' => [
+                ['iframe', 'allowfullscreen', 'Bool'],
+                ['table', 'height', 'Text'],
+                ['td', 'border', 'Text'],
+                ['th', 'border', 'Text'],
+                ['tr', 'width', 'Text'],
+                ['tr', 'height', 'Text'],
+                ['tr', 'border', 'Text'],
+            ],
+        ],
+        'custom_attributes' => [
+            ['a', 'target', 'Enum#_blank,_self,_target,_top'],
+        ],
+        'custom_elements' => [
+            ['u', 'Inline', 'Inline', 'Common'],
         ],
     ],
 

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -39,6 +39,7 @@ return [
         'custom_definition' => [
             'id'  => 'html5-definitions',
             'rev' => 1,
+            'debug' => false,
             'elements' => [
                 // http://developers.whatwg.org/sections.html
                 ['section', 'Block', 'Flow', 'Common'],

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -75,10 +75,119 @@ class Purifier
         }
 
         $config->loadArray($this->getConfig());
+        
+        // Load custom definition if set
+        if ($definitionConfig = $this->config->get('purifier.settings.custom_definition')) {
+	        $this->addCustomDefinition($definitionConfig, $config);
+        }
+        
+        // Load custom elements if set
+        if ($elements = $this->config->get('purifier.settings.custom_elements')) {
+	        if ($def = $config->maybeGetRawHTMLDefinition()) {
+		        $this->addCustomElements($elements, $def);
+	        }
+        }
+        
+        // Load custom attributes if set
+        if ($attributes = $this->config->get('purifier.settings.custom_attributes')) {
+	        if ($def = $config->maybeGetRawHTMLDefinition()) {
+		        $this->addCustomAttributes($attributes, $def);
+	        }
+        }
 
         // Create HTMLPurifier object
         $this->purifier = new HTMLPurifier($this->configure($config));
     }
+    
+    /**
+	 * Add a custom definition
+	 *
+	 * @see http://htmlpurifier.org/docs/enduser-customize.html
+	 * @param array $definitionConfig
+	 * @param HTML_Purifier_Config $configObject Defaults to using default config
+	 * 
+	 * @return HTML_Purifier_Config $configObject
+	 */
+	private function addCustomDefinition(array $definitionConfig, $configObject = null)
+	{
+		if (!$configObject) {
+			$configObject = HTMLPurifier_Config::createDefault();
+			$configObject->loadArray($this->getConfig());
+		}
+		
+		// Setup the custom definition
+		$configObject->set('HTML.DefinitionID', $definitionConfig['id']);
+		$configObject->set('HTML.DefinitionRev', $definitionConfig['rev']);
+		
+		// Enable debug mode
+		if (!isset($definitionConfig['debug']) || $definitionConfig['debug']) {
+			$configObject->set('Cache.DefinitionImpl', null);
+		}
+		
+		// Start configuring the definition
+		if ($def = $configObject->maybeGetRawHTMLDefinition()) {
+			// Create the definition attributes
+			if (!empty($definitionConfig['attributes'])) {
+				$this->addCustomAttributes($definitionConfig['attributes'], $def);
+			}
+			
+			// Create the definition elements
+			if (!empty($definitionConfig['elements'])) {
+				$this->addCustomElements($definitionConfig['elements'], $def);
+			}
+		}
+		
+		return $configObject;
+	}
+	
+	/**
+	 * Add provided attributes to the provided definition
+	 *
+	 * @param array $attributes
+	 * @param HTMLPurifier_HTMLDefinition $definition
+	 * 
+	 * @return HTMLPurifier_HTMLDefinition $definition
+	 */
+	private function addCustomAttributes(array $attributes, $definition)
+	{
+		foreach ($attributes as $attribute) {
+			// Get configuration of attribute
+			$required = !empty($attribute[3]) ? true : false;
+			$onElement = $attribute[0];
+			$attrName = $required ? $attribute[1] . '*' : $attribute[1];
+			$validValues = $attribute[2];
+			
+			$definition->addAttribute($onElement, $attrName, $validValues);
+		}
+		
+		return $definition;
+	}
+	
+	/**
+	 * Add provided elements to the provided definition
+	 *
+	 * @param array $elements
+	 * @param HTMLPurifier_HTMLDefinition $definition
+	 * 
+	 * @return HTMLPurifier_HTMLDefinition $definition
+	 */
+	private function addCustomElements(array $elements, $definition)
+	{
+		foreach ($elements as $element) {
+			// Get configuration of element
+			$name = $element[0];
+			$contentSet = $element[1];
+			$allowedChildren = $element[2];
+			$attributeCollection = $element[3];
+			$attributes = isset($element[4]) ? $element[4] : null;
+			
+			if (!empty($attributes)) {
+				$definition->addElement($name, $contentSet, $allowedChildren, $attributeCollection, $attributes);
+			} else {
+				$definition->addElement($name, $contentSet, $allowedChildren, $attributeCollection);
+			}
+		}
+	}
 
     /**
      * Check/Create cache directory


### PR DESCRIPTION
This implements the elements and attributes for HTML5 defined in https://github.com/kennberg/php-htmlpurfier-html5, and also adds support for defining a custom definition along with adding custom elements and attributes to that definition.

It is fully backwards compatible, existing configurations that don't have the new config values will still work correctly, they just won't see the new definitions until they update their configurations (which they'd need to do anyways to set new properties for the allowable).

This PR correctly implements the desired functionality that was added in #26 by @codel and then removed in #30 by @itbdw because it was broken when users did not update their configurations.

@mewebstudio If you are not willing to continue on with support for this project, then please let me know and I'll be happy to continue it on in my fork on the project.