### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/config": "5.*",
-    "illuminate/support": "5.*",
-    "illuminate/filesystem": "5.*",
+    "illuminate/config": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+    "illuminate/filesystem": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
     "ezyang/htmlpurifier": "4.9.*"
   },
   "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.