### PR TITLE
Properly merge configs

### DIFF
--- a/src/PurifierServiceProvider.php
+++ b/src/PurifierServiceProvider.php
@@ -21,7 +21,22 @@ class PurifierServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $source = $this->getConfigSource();
+        
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            $this->publishes([$source => config_path('purifier.php')]);
+        } elseif ($this->app instanceof LumenApplication) {
+            $this->app->configure('purifier');
+        }
+    }
+    /**
+     * Get the config source.
+     * 
+     * @return string
+     */
+    protected function getConfigSource()
+    {
+        return realpath(__DIR__.'/../config/purifier.php');
     }
 
     /**
@@ -31,15 +46,8 @@ class PurifierServiceProvider extends ServiceProvider
      */
     protected function setupConfig()
     {
-        $source = realpath(__DIR__.'/../config/purifier.php');
-        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
-            $this->publishes([$source => config_path('purifier.php')]);
-        } elseif ($this->app instanceof LumenApplication) {
-            $this->app->configure('purifier');
-        }
-        $this->mergeConfigFrom($source, 'purifier');
+        $this->mergeConfigFrom($this->getConfigSource(), 'purifier');
     }
-
 
     /**
      * Register the service provider.

--- a/src/PurifierServiceProvider.php
+++ b/src/PurifierServiceProvider.php
@@ -21,7 +21,7 @@ class PurifierServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->setupConfig();
+        //
     }
 
     /**
@@ -48,6 +48,8 @@ class PurifierServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->setupConfig();
+        
         $this->app->singleton('purifier', function (Container $app) {
             return new Purifier($app['files'], $app['config']);
         });

--- a/src/PurifierServiceProvider.php
+++ b/src/PurifierServiceProvider.php
@@ -21,14 +21,13 @@ class PurifierServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $source = $this->getConfigSource();
-        
-        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
-            $this->publishes([$source => config_path('purifier.php')]);
+        if ($this->app instanceof LaravelApplication) {
+            $this->publishes([$this->getConfigSource() => config_path('purifier.php')]);
         } elseif ($this->app instanceof LumenApplication) {
             $this->app->configure('purifier');
         }
     }
+
     /**
      * Get the config source.
      * 
@@ -40,23 +39,13 @@ class PurifierServiceProvider extends ServiceProvider
     }
 
     /**
-     * Setup the config.
-     *
-     * @return void
-     */
-    protected function setupConfig()
-    {
-        $this->mergeConfigFrom($this->getConfigSource(), 'purifier');
-    }
-
-    /**
      * Register the service provider.
      *
      * @return void
      */
     public function register()
     {
-        $this->setupConfig();
+        $this->mergeConfigFrom($this->getConfigSource(), 'purifier');
         
         $this->app->singleton('purifier', function (Container $app) {
             return new Purifier($app['files'], $app['config']);


### PR DESCRIPTION
The config should be merged from the `register` method, not the `boot` method.

At the moment this results in an exception when you have not published the configs.
```throw new Exception('Configuration parameters not loaded!');```