### PR TITLE
Update purifier for PHP 7.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/config": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ~6",
     "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ~6",
     "illuminate/filesystem": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ~6",
-    "ezyang/htmlpurifier": "4.11.*"
+    "ezyang/htmlpurifier": "4.12.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
Purifier supports PHP 7.4 from 4.12 as mentioned in #118