### PR TITLE
Add hook which callback when config object was created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,13 @@ Purifier::clean('This is my H1 title', 'titles');
 Purifier::clean('This is my H1 title', array('Attr.EnableID' => true));
 ```
 
+use [URI filter](http://htmlpurifier.org/docs/enduser-uri-filter.html)
+
+```php
+Purifier::clean('This is my H1 title', 'titles', function (HTMLPurifier_Config $config) {
+    $uri = $config->getDefinition('URI');
+    $uri->addFilter(new HTMLPurifier_URIFilter_NameOfFilter(), $config);
+});
+```
+
 for Laravel 4 [HTMLPurifier for Laravel 4](https://github.com/mewebstudio/Purifier/tree/master-l4)

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -240,10 +240,10 @@ class Purifier
     /**
      * @param      $dirty
      * @param null $config
-     *
+     * @param \Closure|null $postCreateConfigHook
      * @return mixed
      */
-    public function clean($dirty, $config = null)
+    public function clean($dirty, $config = null, \Closure $postCreateConfigHook = null)
     {
         if (is_array($dirty)) {
             return array_map(function ($item) use ($config) {
@@ -251,7 +251,16 @@ class Purifier
             }, $dirty);
         }
 
-        return $this->purifier->purify($dirty, $config ? $this->getConfig($config) : null);
+        $configObject = null;
+        if ($config !== null) {
+            $configObject = $this->getConfig($config);
+
+            if ($postCreateConfigHook !== null) {
+                $postCreateConfigHook->call($this, $configObject);
+            }
+        }
+
+        return $this->purifier->purify($dirty, $configObject);
     }
 
     /**


### PR DESCRIPTION
This PR resolve issue(#127) that can't add URI filter if specified config dynamically.