### PR TITLE
Bump ezyang/htmlpurifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/config": "^5.1|^6.0|^7.0",
     "illuminate/support": "^5.1|^6.0|^7.0",
     "illuminate/filesystem": "^5.1|^6.0|^7.0",
-    "ezyang/htmlpurifier": "4.12.*"
+    "ezyang/htmlpurifier": "4.13.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
Hi,

> Deprecation Notice: Class HTMLPurifier_Language_en_x_test located in ./vendor/ezyang/htmlpurifier/library/HTMLPurifier/Language/classes/en-x-test.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

This issue was fixed and released 8 days ago https://github.com/ezyang/htmlpurifier/commit/ce7efc11b20b47bc7f287ee66ef02b6cd4b6fce2. We should use v4.13 to avoid the above issue.

Thanks!