### PR TITLE
Allow explicit non string types through without being cast to empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ Config file `config/purifier.php` should like this
 ```php
 
 return [
-    'encoding'      => 'UTF-8',
-    'finalize'      => true,
-    'cachePath'     => storage_path('app/purifier'),
-    'cacheFileMode' => 0755,
+    'encoding'           => 'UTF-8',
+    'finalize'           => true,
+    'passThruNullValues' => false,
+    'cachePath'          => storage_path('app/purifier'),
+    'cacheFileMode'      => 0755,
     'settings'      => [
         'default' => [
             'HTML.Doctype'             => 'HTML 4.01 Transitional',

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Config file `config/purifier.php` should like this
 return [
     'encoding'           => 'UTF-8',
     'finalize'           => true,
-    'passThruNullValues' => false,
+    'ignoreNonStrings'   => false,
     'cachePath'          => storage_path('app/purifier'),
     'cacheFileMode'      => 0755,
     'settings'      => [

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -19,7 +19,7 @@
 return [
     'encoding'           => 'UTF-8',
     'finalize'           => true,
-    'passThruNullValues' => false,
+    'ignoreNonStrings'   => false,
     'cachePath'          => storage_path('app/purifier'),
     'cacheFileMode'      => 0755,
     'settings'      => [

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -17,10 +17,11 @@
  */
 
 return [
-    'encoding'      => 'UTF-8',
-    'finalize'      => true,
-    'cachePath'     => storage_path('app/purifier'),
-    'cacheFileMode' => 0755,
+    'encoding'           => 'UTF-8',
+    'finalize'           => true,
+    'passThruNullValues' => false,
+    'cachePath'          => storage_path('app/purifier'),
+    'cacheFileMode'      => 0755,
     'settings'      => [
         'default' => [
             'HTML.Doctype'             => 'HTML 4.01 Transitional',

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -273,6 +273,12 @@ class Purifier
             }
         }
 
+        //If $dirty is explicit NULL, bypass purification assuming configuration allows this
+        $passThruNullValues = $this->config->get('purifier.passThruNullValues', false);
+        if($passThruNullValues !== false && $dirty === null) {
+            return null;
+        }
+
         return $this->purifier->purify($dirty, $configObject);
     }
 

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -278,6 +278,9 @@ class Purifier
         if($passThruNullValues !== false && $dirty === null) {
             return null;
         }
+        if($passThruNullValues !== false && $dirty === false) {
+            return false;
+        }
 
         return $this->purifier->purify($dirty, $configObject);
     }

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -273,13 +273,11 @@ class Purifier
             }
         }
 
-        //If $dirty is explicit NULL, bypass purification assuming configuration allows this
-        $passThruNullValues = $this->config->get('purifier.passThruNullValues', false);
-        if($passThruNullValues !== false && $dirty === null) {
-            return null;
-        }
-        if($passThruNullValues !== false && $dirty === false) {
-            return false;
+        //If $dirty is not an explicit string, bypass purification assuming configuration allows this
+        $ignoreNonStrings = $this->config->get('purifier.ignoreNonStrings', false);
+        $stringTest = is_string($dirty);
+        if($stringTest === false && $ignoreNonStrings === true) {
+            return $dirty;
         }
 
         return $this->purifier->purify($dirty, $configObject);

--- a/tests/PurifierTest.php
+++ b/tests/PurifierTest.php
@@ -125,16 +125,21 @@ class PurifierTest extends AbstractTestCase
         $html = null;
         $pureHtml = $purifier->clean($html);
         $this->assertEquals('', $pureHtml);
+        $html = false;
+        $pureHtml = $purifier->clean($html);
+        $this->assertEquals('', $pureHtml);
 
         $html = [
             'good'=>'<span id="some-id">This is my H1 title',
             'bad'=>'<script>alert(\'XSS\');</script>',
             'empty'=>null,
+            'bool'=>false,
         ];
         $expectedHtml = [
             'good'=>'<p><span>This is my H1 title</span></p>',
             'bad'=>'',
             'empty'=>'',
+            'bool'=>'',
         ];
         $pureHtml = $purifier->clean($html);
         $this->assertEquals($expectedHtml, $pureHtml);
@@ -147,19 +152,25 @@ class PurifierTest extends AbstractTestCase
 
         $html = null;
         $pureHtml = $purifier->clean($html);
-        $this->assertEquals('', $pureHtml);
+        $this->assertEquals(null, $pureHtml);
+
+        $html = false;
+        $pureHtml = $purifier->clean($html);
+        $this->assertEquals(false, $pureHtml);
 
         $html = [
             'good'=>'<span id="some-id">This is my H1 title',
             'bad'=>'<script>alert(\'XSS\');</script>',
             'empty'=>null,
             'emptyStr'=>'',
+            'bool'=>false,
         ];
         $expectedHtml = [
             'good'=>'<p><span>This is my H1 title</span></p>',
             'bad'=>'',
             'empty'=>null,
             'emptyStr'=>'',
+            'bool'=>false,
         ];
         $pureHtml = $purifier->clean($html);
         $this->assertEquals($expectedHtml, $pureHtml);

--- a/tests/PurifierTest.php
+++ b/tests/PurifierTest.php
@@ -119,7 +119,7 @@ class PurifierTest extends AbstractTestCase
         $purifier = new Purifier(new Filesystem(), $configRepo);
 
         //test default config value is expected
-        $this->assertEquals(false, $configRepo->get('purifier.passThruNullValues'));
+        $this->assertEquals(false, $configRepo->get('purifier.ignoreNonStrings'));
 
         //Test default behavior is unchanged without nullPassThru Config value of true
         $html = null;
@@ -134,21 +134,25 @@ class PurifierTest extends AbstractTestCase
             'bad'=>'<script>alert(\'XSS\');</script>',
             'empty'=>null,
             'bool'=>false,
+            'bool2'=>true,
+            'float'=>4.321,
         ];
         $expectedHtml = [
             'good'=>'<p><span>This is my H1 title</span></p>',
             'bad'=>'',
             'empty'=>'',
             'bool'=>'',
+            'bool2'=>'<p>1</p>',
+            'float'=>'<p>4.321</p>'
         ];
         $pureHtml = $purifier->clean($html);
         $this->assertEquals($expectedHtml, $pureHtml);
 
 
         //Test behavior as expected with nullPassThru Config value of true
-        $configRepo->set('purifier.passThruNullValues', true);
+        $configRepo->set('purifier.ignoreNonStrings', true);
         $purifier = new Purifier(new Filesystem(), $configRepo);
-        $this->assertEquals(true, $configRepo->get('purifier.passThruNullValues'));
+        $this->assertEquals(true, $configRepo->get('purifier.ignoreNonStrings'));
 
         $html = null;
         $pureHtml = $purifier->clean($html);
@@ -164,6 +168,8 @@ class PurifierTest extends AbstractTestCase
             'empty'=>null,
             'emptyStr'=>'',
             'bool'=>false,
+            'bool2'=>true,
+            'float'=>4.321,
         ];
         $expectedHtml = [
             'good'=>'<p><span>This is my H1 title</span></p>',
@@ -171,6 +177,8 @@ class PurifierTest extends AbstractTestCase
             'empty'=>null,
             'emptyStr'=>'',
             'bool'=>false,
+            'bool2'=>true,
+            'float'=>4.321,
         ];
         $pureHtml = $purifier->clean($html);
         $this->assertEquals($expectedHtml, $pureHtml);


### PR DESCRIPTION
This is a proposed fix for open issue #103 

This config option is OFF by default (including old configs not updated). Test have been added.