### PR TITLE
added custom casts - CleanHtml, CleanHtmlInput, CleanHtmlOutput

### DIFF
--- a/src/Casts/CleanHtml.php
+++ b/src/Casts/CleanHtml.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mews\Purifier\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CleanHtml implements CastsAttributes
+{
+    /**
+     * Clean the HTML when casting the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return clean($value);
+    }
+
+    /**
+     * Prepare the given value for storage by cleaning the HTML.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  array  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return clean($value);
+    }
+}

--- a/src/Casts/CleanHtmlInput.php
+++ b/src/Casts/CleanHtmlInput.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mews\Purifier\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CleanHtmlInput implements CastsAttributes
+{
+    /**
+     * Cast the given value. Does not clean the HTML.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+
+    /**
+     * Prepare the given value for storage by cleaning the HTML.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  array  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return clean($value);
+    }
+}

--- a/src/Casts/CleanHtmlOutput.php
+++ b/src/Casts/CleanHtmlOutput.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mews\Purifier\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CleanHtmlOutput implements CastsAttributes
+{
+    /**
+     * Clean the HTML when casting the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return clean($value);
+    }
+
+    /**
+     * Prepare the given value for storage. Does not clean the HTML.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  array  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/mewebstudio/Purifier/issues/152

Adds three custom casts:
```php
use Mews\Purifier\Casts\CleanHtml;
use Mews\Purifier\Casts\CleanHtmlInput;
use Mews\Purifier\Casts\CleanHtmlOutput;
```

This way, the dev can more easily use HTMLPurifier directly inside their Eloquent models, without writing an accessor or mutator.

I'll follow up with a different PR for documentation.