### PR TITLE
Add custom casts to refreshed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Check out [HTMLPurifier for Laravel 4](https://github.com/mewebstudio/Purifier/t
 
 ## Usage
 
-default
+
+Use these methods inside your requests or middleware, wherever you need the HTML cleaned up:
+
 ```php
 clean(Input::get('inputname'));
 ```
@@ -83,6 +85,28 @@ Purifier::clean('This is my H1 title', 'titles', function (HTMLPurifier_Config $
     $uri = $config->getDefinition('URI');
     $uri->addFilter(new HTMLPurifier_URIFilter_NameOfFilter(), $config);
 });
+```
+
+Alternatively, in Laravel 7+, if you're looking to clean your HTML inside your Eloquent models, you can use our custom casts:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mews\Purifier\Casts\CleanHtml;
+use Mews\Purifier\Casts\CleanHtmlInput;
+use Mews\Purifier\Casts\CleanHtmlOutput;
+
+class Monster extends Model
+{
+    protected $casts = [
+        'bio'            => CleanHtml::class, // cleans both when getting and setting the value
+        'description'    => CleanHtmlInput::class, // cleans when setting the value
+        'history'        => CleanHtmlOutput::class, // cleans when getting the value
+    ];
+}
 ```
 
 ## Configuration


### PR DESCRIPTION
If both https://github.com/mewebstudio/Purifier/pull/153 and https://github.com/mewebstudio/Purifier/pull/154 are merged, this PR adds instructions on how to use the casts, inside the refreshed docs.

The order you should look & merge these PRs @mewebstudio is:
- https://github.com/mewebstudio/Purifier/pull/153 (adds no functionality)
- https://github.com/mewebstudio/Purifier/pull/154 (adds the casts functionality)
- this PR (adds the docs for that functionality above)

If https://github.com/mewebstudio/Purifier/pull/153 is NOT merged, please close this and I'll create a new PR with docs inside the old README, no problem.