### PR TITLE
Adds support for Laravel 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HTMLPurifier for Laravel 5/6/7/8
+# HTMLPurifier for Laravel 5/6/7/8/9
 
 [![Build Status](https://travis-ci.org/mewebstudio/Purifier.svg?branch=master)](https://travis-ci.org/github/mewebstudio/Purifier)
 [![codecov](https://codecov.io/gh/mewebstudio/Purifier/branch/master/graph/badge.svg)](https://codecov.io/gh/mewebstudio/Purifier)

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
   ],
   "require": {
     "php": "^7.2|^8.0",
-    "illuminate/config": "^5.8|^6.0|^7.0|^8.0",
-    "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
-    "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0",
+    "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0",
+    "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0",
+    "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "ezyang/htmlpurifier": "4.13.*"
   },
   "require-dev": {


### PR DESCRIPTION
Hey @mewebstudio ,

Laravel 9 is just around the corner (due in 5 days). I thought we'd get ahead of this thing, and provide support before it's out. Tested this package against L9 and... what do you know, everything still works great 🎉  So it only needs a dependency version bump to support L9. That's what this PR does.

Again, thanks for a great package.
Cheers!

PS. My only concern in terms of breaking changes was [this one](https://laravel.com/docs/master/upgrade#custom-casts-and-null) but it seems it's all fine, `clean(null)` works jus as well as `clean('')`. So we're good 💪