### PR TITLE
Add support custom casts parameters

### DIFF
--- a/src/Casts/CleanHtml.php
+++ b/src/Casts/CleanHtml.php
@@ -33,6 +33,6 @@ class CleanHtml implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        return clean($value);
+        return clean($value, $this->config);
     }
 }

--- a/src/Casts/CleanHtml.php
+++ b/src/Casts/CleanHtml.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class CleanHtml implements CastsAttributes
 {
+    use WithConfig;
+
     /**
      * Clean the HTML when casting the given value.
      *
@@ -17,7 +19,7 @@ class CleanHtml implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
-        return clean($value);
+        return clean($value, $this->config);
     }
 
     /**

--- a/src/Casts/CleanHtmlInput.php
+++ b/src/Casts/CleanHtmlInput.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class CleanHtmlInput implements CastsAttributes
 {
+    use WithConfig;
+
     /**
      * Cast the given value. Does not clean the HTML.
      *
@@ -31,6 +33,6 @@ class CleanHtmlInput implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        return clean($value);
+        return clean($value, $this->config);
     }
 }

--- a/src/Casts/CleanHtmlOutput.php
+++ b/src/Casts/CleanHtmlOutput.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class CleanHtmlOutput implements CastsAttributes
 {
+    use WithConfig;
+
     /**
      * Clean the HTML when casting the given value.
      *
@@ -17,7 +19,7 @@ class CleanHtmlOutput implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
-        return clean($value);
+        return clean($value, $this->config);
     }
 
     /**

--- a/src/Casts/WithConfig.php
+++ b/src/Casts/WithConfig.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mews\Purifier\Casts;
+
+trait WithConfig
+{
+    /**
+     * @var mixed
+     */
+    protected $config;
+
+    public function __construct($config = null)
+    {
+        $this->config = $config;
+    }
+}


### PR DESCRIPTION
I need the ability to pass the parameters to the custom casts #166 
This PR allows you to do it:

```php
class Template extends Model
{
    protected $casts = [
        'html_content' => CleanHtmlOutput::class . ':template'
    ];
}
```

https://laravel.com/docs/8.x/eloquent-mutators#cast-parameters