### PR TITLE
Automatically instantiate attributes using php class names

### DIFF
--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -143,7 +143,11 @@ class Purifier
                 }
 
                 continue;
-            }
+	    }
+
+	    if (class_exists($validValues)) {
+		$validValues = new $validValues();
+	    }
 
             $definition->addAttribute($onElement, $attrName, $validValues);
         }


### PR DESCRIPTION
Faced an issue today where attributes containing class names were not automatically instantiated when reading the config.

Example:

```php
'attributes' => [
                ['iframe', 'allowfullscreen', 'Bool'],
                ...
                ['img', 'src', \App\Purifier\CustomAttrDef::class]
],
```

The following works but throws an error when running artisan config:cache since it can't serialize the object in config:

```php
'attributes' => [
                ['iframe', 'allowfullscreen', 'Bool'],
                ...
                ['img', 'src', new \App\Purifier\CustomAttrDef()]
],
```