### PR TITLE
Upgrade ezyang/htmlpurifier up to 4.16.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0",
-    "ezyang/htmlpurifier": "4.13.*"
+    "ezyang/htmlpurifier": "4.16.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",


### PR DESCRIPTION
The new version of [ezyang/htmlpurifier](https://github.com/ezyang/htmlpurifier) adds support for PHP 8.1 