### PR TITLE
fix: connot install phpoffice/phpspreadsheet:^1.25

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0",
-    "ezyang/htmlpurifier": "4.13.*"
+    "ezyang/htmlpurifier": "^4.13"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",


### PR DESCRIPTION
closed #177

this command can use latest `ezyang/htmlpurifier` can be close #176 

```
composer config repositories.purifier vcs https://github.com/mouyong/Purifier
composer require mews/purifier:dev-master
```

when install laravel-excel in laravel 9, use below command
```
composer require psr/simple-cache:^2.0 maatwebsite/excel mews/purifier:dev-master
```