### PR TITLE
Updated composer so the tag can be used. Updated tests accordingly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0",
     "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0",
-    "ezyang/htmlpurifier": "^4.16.*"
+    "ezyang/htmlpurifier": "^4.16"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Laravel Purifier Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -14,7 +14,7 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
      *
      * @return string
      */
-    protected function getServiceProviderClass($app)
+    protected function getServiceProviderClass()
     {
         return PurifierServiceProvider::class;
     }


### PR DESCRIPTION
Latest version 3.3.9 is not able to be used by composer due to a bad version constraint:

`Skipped branch master, Could not parse version constraint ^4.16.*: Invalid version string "^4.16.*"`

Updated also test in order to work with `GrahamCampbell\TestBench\getServiceProviderClass` 
