### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
-    "ezyang/htmlpurifier": "^4.16.0"
+    "ezyang/htmlpurifier": "^4.17.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0|^10.0",


### PR DESCRIPTION
As of now this is the message that I get by trying to update my web app to PHP 8.3.

```
Problem 1
  - ezyang/htmlpurifier v4.16.0 requires php ~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 -> your php version (8.3.0) does not satisfy that requirement.
  - mews/purifier 3.4.1 requires ezyang/htmlpurifier ^4.16.0 -> satisfiable by ezyang/htmlpurifier[v4.16.0].
  - mews/purifier is locked to version 3.4.1 and an update of this package was not requested.
```

With this change, while updating a web app to PHP 8.3, the conflicting package should be automatically upgraded.