### PR TITLE
Eliminate race condition in makeDirectory

### DIFF
--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -194,7 +194,7 @@ class Purifier
                 $this->config->get('purifier.cacheFileMode', 0755),
                 true,
                 true
-	    );
+            );
         }
     }
 

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -189,9 +189,12 @@ class Purifier
         $cachePath = $this->config->get('purifier.cachePath');
 
         if ($cachePath) {
-            if (!$this->files->isDirectory($cachePath)) {
-                $this->files->makeDirectory($cachePath, $this->config->get('purifier.cacheFileMode', 0755),true);
-            }
+            $this->files->makeDirectory(
+		$cachePath,
+		$this->config->get('purifier.cacheFileMode', 0755),
+		true,
+	    	true
+	    );
         }
     }
 

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -190,10 +190,10 @@ class Purifier
 
         if ($cachePath) {
             $this->files->makeDirectory(
-		$cachePath,
-		$this->config->get('purifier.cacheFileMode', 0755),
-		true,
-	    	true
+                $cachePath,
+                $this->config->get('purifier.cacheFileMode', 0755),
+                true,
+                true
 	    );
         }
     }


### PR DESCRIPTION
This code should not check whether the directory exists.

With parallel tests running in the same code area, you have a race condition between these two points:

* does the directory exist
* create the directory

One test sees the directory does not exist, and tries to create it. At the same time another test has created it.
Now the first test fails because the directory now exists.

To fix this, you should not check anything and use the force option which this PR implements - if the directory exists at the time of creation, it will ignore it and carry on with the rest of the process.